### PR TITLE
Fix for #7

### DIFF
--- a/packaging/wrappers/uaac.sh
+++ b/packaging/wrappers/uaac.sh
@@ -10,4 +10,4 @@ export BUNDLE_GEMFILE="$SELFDIR/lib/vendor/Gemfile"
 unset BUNDLE_IGNORE_CONFIG
 
 # Run the actual app using the bundled Ruby interpreter, with Bundler activated.
-exec "$SELFDIR/lib/ruby/bin/ruby" -rbundler/setup $SELFDIR/lib/vendor/ruby/2.1.0/bin/uaac $@
+exec "$SELFDIR/lib/ruby/bin/ruby" -rbundler/setup $SELFDIR/lib/vendor/ruby/2.1.0/bin/uaac "$@"


### PR DESCRIPTION
previously, option values with spaces would be split causing "Too many command line parameters given."
